### PR TITLE
Add Eigen and Orocos_kdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # tesseract_ext
-This contains external dependencies for Tesseract
+This contains external dependencies for Tesseract.
+
+## Required Dependencies
+* Bullet3
+* FCL
+* GTest
+
+## Optional Dependencies
+These are optional and not required for typical operation
+* Eigen3 - Bug fixes that are not available in release version are useful in some cases
+  * Enable with -DINSTALL_EIGEN=ON
+  * Select custom git tag with -DINSTALL_EIGEN_TAG=tag_name
+* Orocos_kdl - Must be built from source when using a custom Eigen version
+  * Enable with -DINSTALL_OROCOS_KDL=ON
+  * Select custom git tag with -DINSTALL_OROCOS_KDL_TAG=tag_name

--- a/bullet3/CMakeLists.txt
+++ b/bullet3/CMakeLists.txt
@@ -9,6 +9,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   ExternalProject_Add(Bullet
     GIT_REPOSITORY    https://github.com/bulletphysics/bullet3.git
     GIT_TAG           master
+    GIT_SHALLOW       ON
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/bullet3-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/bullet3-build
     CMAKE_CACHE_ARGS
@@ -24,6 +25,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   ExternalProject_Add(Bullet
     GIT_REPOSITORY    https://github.com/bulletphysics/bullet3.git
     GIT_TAG           master
+    GIT_SHALLOW       ON
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/bullet3-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/bullet3-build
     CMAKE_CACHE_ARGS

--- a/eigen/CMakeLists.txt
+++ b/eigen/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(eigen3)
+
+find_package(Eigen3 QUIET)
+if ( NOT ${Eigen3_FOUND} OR INSTALL_EIGEN)
+  if (NOT INSTALL_EIGEN_TAG)
+    set(INSTALL_EIGEN_TAG master)
+  endif()
+
+  include(ExternalProject)
+
+  ExternalProject_Add(Eigen3
+    GIT_REPOSITORY    https://gitlab.com/libeigen/eigen.git
+    GIT_TAG           ${INSTALL_EIGEN_TAG}
+    GIT_SHALLOW       ON
+    SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/Eigen3-src
+    BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/Eigen3-build
+    CMAKE_CACHE_ARGS
+            -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_BUILD_TYPE:STRING=Release
+  )
+endif()
+
+install(FILES package.xml DESTINATION share/Eigen3)

--- a/eigen/package.xml
+++ b/eigen/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>eigen3</name>
+  <version>0.1.0</version>
+  <description>Eigen3 Package</description>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
+  <license>Unknown</license>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
+</package>

--- a/fcl/CMakeLists.txt
+++ b/fcl/CMakeLists.txt
@@ -9,6 +9,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   ExternalProject_Add(fcl
     GIT_REPOSITORY    https://github.com/flexible-collision-library/fcl.git
     GIT_TAG           master
+    GIT_SHALLOW       ON
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/fcl-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/fcl-build
     CMAKE_CACHE_ARGS
@@ -23,6 +24,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   ExternalProject_Add(fcl
     GIT_REPOSITORY    https://github.com/flexible-collision-library/fcl.git
     GIT_TAG           master
+    GIT_SHALLOW       ON
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/fcl-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/fcl-build
     CMAKE_CACHE_ARGS

--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -12,6 +12,7 @@ if ( NOT ${GTest_FOUND} )
     ExternalProject_Add(GTest
       GIT_REPOSITORY    https://github.com/google/googletest.git
       GIT_TAG           release-1.8.1
+      GIT_SHALLOW       ON
       SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/googletest-src
       BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/googletest-build
       CMAKE_CACHE_ARGS
@@ -27,6 +28,7 @@ if ( NOT ${GTest_FOUND} )
     ExternalProject_Add(GTest
       GIT_REPOSITORY    https://github.com/google/googletest.git
       GIT_TAG           release-1.8.1
+      GIT_SHALLOW       ON
       SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/googletest-src
       BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/googletest-build
       CMAKE_CACHE_ARGS

--- a/libccd/CMakeLists.txt
+++ b/libccd/CMakeLists.txt
@@ -8,6 +8,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   ExternalProject_Add(libccd
     GIT_REPOSITORY    https://github.com/danfis/libccd.git
     GIT_TAG           master
+    GIT_SHALLOW       ON
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/libccd-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/libccd-build
     CMAKE_CACHE_ARGS
@@ -21,6 +22,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   ExternalProject_Add(libccd
     GIT_REPOSITORY    https://github.com/danfis/libccd.git
     GIT_TAG           master
+    GIT_SHALLOW       ON
     SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/libccd-src
     BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/libccd-build
     CMAKE_CACHE_ARGS

--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(orocos_kdl)
+
+find_package(orocos_kdl QUIET)
+if ( NOT ${orocos_kdl_FOUND} OR INSTALL_OROCOS_KDL)
+  if (NOT INSTALL_OROCOS_KDL_TAG)
+    set(INSTALL_OROCOS_KDL_TAG "1.3.2")
+  endif()
+
+  include(ExternalProject)
+
+  ExternalProject_Add(orocos_kdl
+    GIT_REPOSITORY    https://github.com/orocos/orocos_kinematics_dynamics.git
+    GIT_TAG           ${INSTALL_OROCOS_KDL_TAG}
+    GIT_SHALLOW       ON
+    SOURCE_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/orocos_kdl-src
+    BINARY_DIR        ${CMAKE_BINARY_DIR}/../tesseract_ext/orocos_kdl-build
+    SOURCE_SUBDIR     orocos_kdl
+    CMAKE_CACHE_ARGS
+            -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_BUILD_TYPE:STRING=Release
+  )
+endif()
+
+install(FILES package.xml DESTINATION share/orocos_kdl)

--- a/orocos_kdl/package.xml
+++ b/orocos_kdl/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>orocos_kdl</name>
+  <version>0.1.0</version>
+  <description>orocos_kdl Package</description>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
+  <license>Unknown</license>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
+</package>


### PR DESCRIPTION
The latest version of Eigen has features like STL iterators and eliminates the issues with alignment in objects containing Eigen types. However, using later versions breaks KDL. So that is necessary as well.   Neither of these are currently required by any feature in Tesseract, but they will be necessary for some optional features that are anticipated. 

It is also worth noting that both of these packages are pretty lightweight and shouldn't bog down build times. I would actually expect that build times will go down with this pull request due to enabling GIT_SHALLOW.