### PR TITLE
Taskflow: Disable CUDA

### DIFF
--- a/taskflow/CMakeLists.txt
+++ b/taskflow/CMakeLists.txt
@@ -20,7 +20,10 @@ if (NOT Taskflow_FOUND OR INSTALL_TASKFLOW)
             CMAKE_CACHE_ARGS
             -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
             -DCMAKE_BUILD_TYPE:STRING=Release
-            -DBUILD_TESTING=OFF
+            -DTF_BUILD_BENCHMARKS:BOOL=OFF
+            -DTF_BUILD_CUDA:BOOL=OFF
+            -DTF_BUILD_TESTS:Bool=OFF
+            -DTF_BUILD_EXAMPLES:Bool=OFF
             )
 
         install(FILES package.xml DESTINATION share/Taskflow)


### PR DESCRIPTION
I'm not sure what is involved with using CUDA, but getting it to build on a CUDA enabled computer doesn't "just work" in my experience. Since we are not using CUDA features, this disables building it.