### PR TITLE
Add OMPL as an optional package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ These are optional and not required for typical operation
 * Eigen3 - Bug fixes that are not available in release version are useful in some cases
   * Enable with `-DINSTALL_EIGEN=ON`
   * Select custom git tag with `-DINSTALL_EIGEN_TAG=tag_name`
+* OMPL - For using a nonstandard OMPL version
+  * Enable with `-DINSTALL_OMPL=ON`
+  * Select custom git tag with `-DINSTALL_OMPL_TAG=tag_name`
 * Orocos_kdl - Must be built from source when using a custom Eigen version
   * Enable with `-DINSTALL_OROCOS_KDL=ON`
   * Select custom git tag with `-DINSTALL_OROCOS_KDL_TAG=tag_name`

--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -24,6 +24,7 @@ if (NOT ompl OR INSTALL_OMPL)
             -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
             -DCMAKE_BUILD_TYPE:STRING=Release
             -D_USE_MATH_DEFINES:BOOL=ON
+            -DOMPL_BUILD_DEMOS:BOOL=OFF
   )
 
   install(FILES package.xml DESTINATION share/ompl)

--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(ompl)
+
+find_package(ompl QUIET)
+if (NOT ompl OR INSTALL_OMPL)
+
+  if (NOT UPDATE_DISCONNECTED)
+    set(UPDATE_DISCONNECTED ON)
+  endif()
+
+  if (NOT INSTALL_OMPL_TAG)
+    set(INSTALL_OMPL_TAG "1.5.0")
+  endif()
+
+  include(ExternalProject)
+
+  ExternalProject_Add(ompl
+    GIT_REPOSITORY        https://github.com/ompl/ompl.git
+    GIT_TAG               ${INSTALL_OMPL_TAG}
+    SOURCE_DIR            ${CMAKE_BINARY_DIR}/../tesseract_ext/ompl-src
+    BINARY_DIR            ${CMAKE_BINARY_DIR}/../tesseract_ext/ompl-build
+    UPDATE_DISCONNECTED   ${UPDATE_DISCONNECTED}
+    CMAKE_CACHE_ARGS
+            -DCMAKE_INSTALL_PREFIX:STRING=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_BUILD_TYPE:STRING=Release
+            -D_USE_MATH_DEFINES:BOOL=ON
+  )
+
+  install(FILES package.xml DESTINATION share/ompl)
+else()
+  install(FILES package.xml DESTINATION share/dummy RENAME ompl.xml)
+endif()
+

--- a/ompl/package.xml
+++ b/ompl/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ompl</name>
+  <version>0.1.0</version>
+  <description>ompl Package</description>
+  <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
+  <license>BSD</license>
+
+  <depend>boost</depend>
+  <depend>eigen</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+
+</package>


### PR DESCRIPTION
I thought I would see if there was interest in adding this since I already had it. I had to build OMPL from source because of [this issue on 1.4.2](https://github.com/ompl/ompl/issues/664). This PR adds it as an optional dependency like Eigen or KDL.