### PR TITLE
Correct ompl_FOUND flag

### DIFF
--- a/ompl/CMakeLists.txt
+++ b/ompl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(ompl)
 
 find_package(ompl QUIET)
-if (NOT ompl OR INSTALL_OMPL)
+if (NOT ompl_FOUND OR INSTALL_OMPL)
 
   if (NOT UPDATE_DISCONNECTED)
     set(UPDATE_DISCONNECTED ON)


### PR DESCRIPTION
Before ompl was always being built because the wrong variable was being checked